### PR TITLE
convert message data from bytearray to bytes in httpgateway wsgi app

### DIFF
--- a/Pyro5/utils/httpgateway.py
+++ b/Pyro5/utils/httpgateway.py
@@ -248,12 +248,12 @@ def process_pyro_request(environ, path, parameters, start_response):
                 elif msg.flags & protocol.FLAGS_EXCEPTION:
                     # got an exception response so send a 500 status
                     start_response('500 Internal Server Error', [('Content-Type', 'application/json; charset=utf-8')])
-                    return [msg.data]
+                    return [bytes(msg.data)]
                 else:
                     # normal response
                     start_response('200 OK', [('Content-Type', 'application/json; charset=utf-8'),
                                               ('X-Pyro-Correlation-Id', str(callcontext.current_context.correlation_id))])
-                    return [msg.data]
+                    return [bytes(msg.data)]
     except Exception as x:
         stderr = environ["wsgi.errors"]
         print("ERROR handling {0} with params {1}:".format(path, parameters), file=stderr)


### PR DESCRIPTION
The http example was failing for me with the following:

  File "C:\Users\pcreinhold\Miniconda3\lib\wsgiref\handlers.py", line 138, in run
    self.finish_response()
  File "C:\Users\pcreinhold\Miniconda3\lib\wsgiref\handlers.py", line 184, in finish_response
    self.write(data)
  File "C:\Users\pcreinhold\Miniconda3\lib\wsgiref\handlers.py", line 279, in write
    "write() argument must be a bytes instance"

It looks like the data being returned was a bytearray, not a bytes.