### PR TITLE
serialize/deserialize remote exception traceback

### DIFF
--- a/Pyro5/client.py
+++ b/Pyro5/client.py
@@ -240,7 +240,8 @@ class Proxy(object):
                         raise errors.ProtocolError("result of call is an iterator, but the server is not configured to allow streaming")
                     return _StreamResultIterator(streamId, self)
                 if msg.flags & protocol.FLAGS_EXCEPTION:
-                    raise data  # if you see this in your traceback, you should probably inspect the remote traceback as well
+                    ____REMOTE__EXCEPTION__TRACEBACK__FOLLOWS____=data
+                    raise ____REMOTE__EXCEPTION__TRACEBACK__FOLLOWS____
                 else:
                     return data
         except (errors.CommunicationError, KeyboardInterrupt):

--- a/Pyro5/serializers.py
+++ b/Pyro5/serializers.py
@@ -17,6 +17,7 @@ import marshal
 import json
 import serpent
 import contextlib
+import tblib
 try:
     import msgpack
 except ImportError:
@@ -140,7 +141,8 @@ class SerializerBase(object):
                 "__class__": obj.__class__.__module__ + "." + obj.__class__.__name__,
                 "__exception__": True,
                 "args": obj.args,
-                "attributes": vars(obj)  # add custom exception attributes
+                "__traceback__": tblib.Traceback(obj.__traceback__).to_dict(),
+                "attributes": vars(obj) # add custom exception attributes
             }
         try:
             value = obj.__getstate__()
@@ -239,6 +241,7 @@ class SerializerBase(object):
             # restore custom attributes on the exception object
             for attr, value in data["attributes"].items():
                 setattr(ex, attr, value)
+        ex.__traceback__=tblib.Traceback.from_dict(data['__traceback__']).as_traceback()
         return ex
 
     def recreate_classes(self, literal):

--- a/Pyro5/serializers.py
+++ b/Pyro5/serializers.py
@@ -241,7 +241,8 @@ class SerializerBase(object):
             # restore custom attributes on the exception object
             for attr, value in data["attributes"].items():
                 setattr(ex, attr, value)
-        ex.__traceback__=tblib.Traceback.from_dict(data['__traceback__']).as_traceback()
+        if '__traceback__' in data:
+            ex.__traceback__=tblib.Traceback.from_dict(data['__traceback__']).as_traceback()
         return ex
 
     def recreate_classes(self, literal):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 serpent>=1.27
+tblib


### PR DESCRIPTION
I find this quite helpful when debugging - the traceback shows both the local and remote part. It introduces a dependency on `tblib` (for serializing the traceback object) which might or might not be acceptable.