### PR TITLE
Remove deprecation warning in 3.10

### DIFF
--- a/Pyro5/server.py
+++ b/Pyro5/server.py
@@ -286,7 +286,7 @@ class Daemon(object):
         log.info("daemon %s entering requestloop", self.locationStr)
         try:
             self.__loopstopped.clear()
-            self.transportServer.loop(loopCondition=lambda: not self.__mustshutdown.isSet() and loopCondition())
+            self.transportServer.loop(loopCondition=lambda: not self.__mustshutdown.is_set() and loopCondition())
         finally:
             self.__loopstopped.set()
         log.debug("daemon exits requestloop")


### PR DESCRIPTION
Smallest pull request in the history of pull requests:

server.py:289 used threading.Event's ``isSet()``, which is deprecated in Python 3.10 in favor of ``is_set()``. I have modified this one line.
server.py:312 is already using ``is_set()``, so this brings more consistency, anyway. No reason to keep isSet().

I'm using Python 3.10, and got tired of the deprecation warning every time I imported my package or used anything from the server module. Hence, this small update. :smile: 