### PR TITLE
Correct minimum Python version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 zip_safe = True
 include_package_data = False
 packages = Pyro5, Pyro5.utils, Pyro5.compatibility
-python_requires = >=3.2
+python_requires = >=3.7
 install_requires =
     serpent>=1.41
 


### PR DESCRIPTION
The release notes specify that the minimum supported Python version is 3.7, which is not reflected in setup.cfg.