### PR TITLE
Improve registration robustness for instances of registered classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /.eggs/
 /.mypy_cache/
 /.pytest_cache/
+.venv/

--- a/Pyro5/server.py
+++ b/Pyro5/server.py
@@ -649,7 +649,8 @@ class Daemon(object):
             if not hasattr(obj_or_class, "_pyroInstancing"):
                 obj_or_class._pyroInstancing = ("session", None)
         if not force:
-            if hasattr(obj_or_class, "_pyroId") and obj_or_class._pyroId != "":  # check for empty string is needed for Cython
+            pyro_id = getattr(obj_or_class, "_pyroId", None)
+            if pyro_id and self.objectsById[pyro_id] is obj_or_class:
                 raise errors.DaemonError("object or class already has a Pyro id")
             if objectId in self.objectsById:
                 raise errors.DaemonError("an object or class is already registered with that id")


### PR DESCRIPTION
I am trying to remotely control a very OO interface by leveraging Pyro5's autoproxying features

I implemented a version of this workaround in a util function in the module I was working on and thought the same case might cause issues for others too.

The issue arrises when you do something like:

```python
from kigadgets.util import register_return
from Pyro5.api import expose, Daemon

daemon = Daemon()

@expose
class Returned(object):
    pass  # not important

daemon.register(Returned)

@expose
class Dummy(object):
    @property
    def thingo(self) -> Returned:
        result = Returned()
        self._pyroDaemon.register(result)
        return result

dummy = Dummy()
daemon.register(dummy)
dummy.thingo
```