### PR TITLE
Adding concurrency and Functor conveniences

### DIFF
--- a/Pyro5/api.py
+++ b/Pyro5/api.py
@@ -12,7 +12,7 @@ from . import __version__
 from .configure import global_config as config
 from .core import URI, locate_ns, resolve, type_meta
 from .client import Proxy, BatchProxy, ConcurrentProxy, SerializedBlob
-from .server import Daemon, DaemonObject, callback, expose, behavior, oneway, serve
+from .server import Daemon, DaemonObject, callback, expose, behavior, oneway, serve, Functor
 from .nameserver import start_ns, start_ns_loop
 from .serializers import SerializerBase
 from .callcontext import current_context
@@ -25,6 +25,6 @@ unregister_class_to_dict = SerializerBase.unregister_class_to_dict
 
 __all__ = ["config", "URI", "locate_ns", "resolve", "type_meta", "current_context",
            "Proxy", "BatchProxy", "ConcurrentProxy", "SerializedBlob", "SerializerBase",
-           "Daemon", "DaemonObject", "callback", "expose", "behavior", "oneway",
+           "Daemon", "DaemonObject", "callback", "expose", "behavior", "oneway", "Functor",
            "start_ns", "start_ns_loop", "serve", "register_dict_to_class",
            "register_class_to_dict", "unregister_dict_to_class", "unregister_class_to_dict"]

--- a/Pyro5/api.py
+++ b/Pyro5/api.py
@@ -11,7 +11,7 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 from . import __version__
 from .configure import global_config as config
 from .core import URI, locate_ns, resolve, type_meta
-from .client import Proxy, BatchProxy, SerializedBlob
+from .client import Proxy, BatchProxy, ConcurrentProxy, SerializedBlob
 from .server import Daemon, DaemonObject, callback, expose, behavior, oneway, serve
 from .nameserver import start_ns, start_ns_loop
 from .serializers import SerializerBase
@@ -24,7 +24,7 @@ unregister_class_to_dict = SerializerBase.unregister_class_to_dict
 
 
 __all__ = ["config", "URI", "locate_ns", "resolve", "type_meta", "current_context",
-           "Proxy", "BatchProxy", "SerializedBlob", "SerializerBase",
+           "Proxy", "BatchProxy", "ConcurrentProxy", "SerializedBlob", "SerializerBase",
            "Daemon", "DaemonObject", "callback", "expose", "behavior", "oneway",
            "start_ns", "start_ns_loop", "serve", "register_dict_to_class",
            "register_class_to_dict", "unregister_dict_to_class", "unregister_class_to_dict"]

--- a/Pyro5/client.py
+++ b/Pyro5/client.py
@@ -182,6 +182,7 @@ class Proxy(object):
     # obj.__getitem__(index)), the special methods are not looked up via __getattr__
     # for efficiency reasons; instead, their presence is checked directly.
     # Thus we need to define them here to force (remote) lookup through __getitem__.
+    def __call__(self, *args, **kwargs): return self.__getattr__('__call__')(*args, **kwargs)
     def __bool__(self): return True
     def __len__(self): return self.__getattr__('__len__')()
     def __getitem__(self, index): return self.__getattr__('__getitem__')(index)

--- a/Pyro5/server.py
+++ b/Pyro5/server.py
@@ -17,7 +17,7 @@ import warnings
 import weakref
 import serpent
 import ipaddress
-from typing import TypeVar, Tuple, Union, Optional, Dict, Any, Sequence, Set
+from typing import Generic, ParamSpec, TypeVar, Tuple, Union, Optional, Dict, Any, Sequence, Set
 from . import config, core, errors, serializers, socketutil, protocol, client
 from .callcontext import current_context
 from collections.abc import Callable
@@ -29,7 +29,7 @@ log = logging.getLogger("Pyro5.server")
 
 _private_dunder_methods = frozenset([
     "__init__", "__init_subclass__", "__class__", "__module__", "__weakref__",
-    "__call__", "__new__", "__del__", "__repr__",
+    "__new__", "__del__", "__repr__",
     "__str__", "__format__", "__nonzero__", "__bool__", "__coerce__",
     "__cmp__", "__eq__", "__ne__", "__hash__", "__ge__", "__gt__", "__le__", "__lt__",
     "__dir__", "__enter__", "__exit__", "__copy__", "__deepcopy__", "__sizeof__",
@@ -136,6 +136,26 @@ def behavior(instance_mode: str = "session", instance_creator: Optional[Callable
     if not isinstance(instance_mode, str):
         raise SyntaxError("behavior decorator is missing argument(s)")
     return _behavior
+
+
+ReturnType = TypeVar("ReturnType")
+ParamsTypes = ParamSpec("ParamsTypes")
+
+@expose
+class Functor(Generic[ParamsTypes, ReturnType]):
+    """
+    A functor is a callable object that can be used as a function.
+    This is used to wrap functions that are not methods of a class.
+    """
+
+    def __init__(self, func: Callable[ParamsTypes, ReturnType]):
+        self.func = func
+
+    @expose
+    def __call__(
+        self, *args: ParamsTypes.args, **kwargs: ParamsTypes.kwargs
+    ) -> ReturnType:
+        return self.func(*args, **kwargs)
 
 
 @expose

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1032,7 +1032,6 @@ class TestMetaAndExpose:
         assert Pyro5.server.is_private_attribute("___p")
         assert not Pyro5.server.is_private_attribute("__dunder__")  # dunder methods should not be private except a list of exceptions as tested below
         assert Pyro5.server.is_private_attribute("__init__")
-        assert Pyro5.server.is_private_attribute("__call__")
         assert Pyro5.server.is_private_attribute("__new__")
         assert Pyro5.server.is_private_attribute("__del__")
         assert Pyro5.server.is_private_attribute("__repr__")


### PR DESCRIPTION
## Goals
Pyro5 is a great library to accelerate development for python IPC projects. However, it lacks two things that are necessary for our use cases.

Firstly, it doesn't have convenient concurrent communication support.  Only 1 thread on the client can use a Proxy at once. The stated workaround for this is to pass around the URI instead of the proxy, but this has 2 drawbacks:
1. It is inconvenient and some of the transparency that is gained from having a proxy in the first place is lost. Consumers of the proxy now need to give it special treatment.
2. It doesn't address the issue of proxies unknowingly crossing thread boundaries. meaning that no proxy can safely be passed around if there is a chance that it will be put onto another thread.

Secondly, it is inconvenient to not be able to auto-proxy methods with un-exposed classes. The two biggest occurrences of this are: giving callbacks to the server that are regular functions or lambdas (base class e.g.: `builtins.function`) or using a method of a normal object as a callback (i.e. my_queue.put).

## Implementation

### Concurrency
There are some challenges to implementing socket-level concurrency in Pyro. The protocol expects messages to come in the right order, so un-collating a concurrent message stream would be a bit annoying. So with the stated goals in mind, I decided to create a new class, `ConcurrentProxy` that will perform the intended workflow, but automatically. 

If you are not careful with this, it is possible to cause significant memory growth that is unnecessary as well as unnecessary chatter. 

### Function Calling
I created a new class, `Functor` that can be used to wrap and expose methods that otherwise aren't exposed by their original owning class. To make this work more conveniently, I also removed `__call__` from the dunder method private list.

Now you can wrap functions or lambdas with `Pyro5.api.Functor` and call them like functions on the server side.


## Feedback Request

I am sure there is a better way to correctly manage concurrent proxies. So I am interested in feedback there. 
Also, I am not totally sure *why* `__call__` was on the private list to begin with. If there is some reason I am missing, I would be interested to know.
