### PR TITLE
Fix exception leaks

### DIFF
--- a/Pyro5/client.py
+++ b/Pyro5/client.py
@@ -272,7 +272,10 @@ class Proxy(object):
                         raise errors.ProtocolError("result of call is an iterator, but the server is not configured to allow streaming")
                     return _StreamResultIterator(streamId, self)
                 if msg.flags & protocol.FLAGS_EXCEPTION:
-                    raise data  # if you see this in your traceback, you should probably inspect the remote traceback as well
+                    try:
+                        raise data  # if you see this in your traceback, you should probably inspect the remote traceback as well
+                    finally:
+                        del data
                 else:
                     return data
         except (errors.CommunicationError, KeyboardInterrupt):

--- a/Pyro5/core.py
+++ b/Pyro5/core.py
@@ -153,7 +153,13 @@ class _ExceptionWrapper(object):
         self.exception = exception
 
     def raiseIt(self):
-        raise self.exception
+        try:
+            err = self.exception.__class__(*self.exception.args)
+            if hasattr(self.exception, '_pyroTraceback'):
+                err._pyroTraceback = self.exception._pyroTraceback
+            raise err
+        finally:
+            del err
 
     def __serialized_dict__(self):
         """serialized form as a dictionary"""

--- a/Pyro5/socketutil.py
+++ b/Pyro5/socketutil.py
@@ -154,9 +154,12 @@ def receive_data(sock: socket.socket, size: int) -> bytes:
                     data.extend(chunk)
                     msglen += len(chunk)
                 if len(data) != size:
-                    err = ConnectionClosedError("receiving: not enough data")
-                    err.partialData = data  # store the message that was received until now
-                    raise err
+                    try:
+                        err = ConnectionClosedError("receiving: not enough data")
+                        err.partialData = data  # store the message that was received until now
+                        raise err
+                    finally:
+                        del err
                 return data  # yay, complete
             except socket.timeout:
                 raise TimeoutError("receiving: timeout")


### PR DESCRIPTION
I found that some proxies aren't garbage collected. The reason are exceptions raised from variables, because they create circular references, preventing automatic garbage collection. You may read more [here](https://cosmicpercolator.com/2016/01/13/exception-leaks-in-python-2-and-3/).

Here is the sample code fixed by this PR:
```py
import threading
import weakref
from Pyro5.api import Daemon, Proxy, BatchProxy, expose


@expose
class Hello:
    def __init__(self):
        pass

    def raise_exception(self):
        raise RuntimeError("Error")


daemon = Daemon()
uri = daemon.register(Hello)

threading.Thread(target=lambda: daemon.requestLoop(), daemon=True).start()

def test():
    proxy = Proxy(uri)
    try:
        proxy.raise_exception()
    except Exception as exc:
        print("Exception is captured:", exc)
    return weakref.ref(proxy)

ref = test()
assert not ref(), "Leaked after Proxy call"

def test():
    proxy = Proxy(uri)
    batch = BatchProxy(proxy)
    batch.raise_exception()
    try:
        next(batch())
    except Exception as exc:
        print("Exception is captured:", exc)
    return weakref.ref(proxy)

ref = test()
assert not ref(), "Leaked after BatchProxy call"
```